### PR TITLE
Enforce owner wait lock and prevent owner-side polling

### DIFF
--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -134,6 +134,7 @@ subprocess.run([
 | `send_message` | メッセージ送信（単一宛先/ブロードキャスト） | Owner, Admin, Worker |
 | `read_messages` | メッセージ読み取り（既読管理つき） | Owner, Admin, Worker |
 | `get_unread_count` | 未読数取得 | Owner, Admin, Worker |
+| `unlock_owner_wait` | Owner 待機ロックの手動解除（非常時のみ） | Owner |
 | `register_agent_to_ipc` | IPC ディレクトリを事前登録 | Owner, Admin |
 
 ### 関連ツール（Dashboard 側）
@@ -158,6 +159,15 @@ subprocess.run([
 ### Admin が覚えておくこと
 
 1. **Worker 完了待ち**: tmux 通知が来たら `read_messages` で内容を確認（イベント駆動、ポーリング不要）
+
+### Owner が覚えておくこと
+
+1. **send_task 後は待機ロック**: Owner→Admin の `send_task` 成功後、Owner は待機ロック状態になります
+2. **待機中の許可ツールは限定**: `read_messages` / `get_unread_count` / `unlock_owner_wait` のみ実行可能
+3. **ポーリング抑止**: 待機中に `read_messages(unread_only=true)` で unread=0 の連続確認をすると
+   `polling_blocked` が返されます
+4. **解除条件**: `read_messages` で Admin 由来メッセージを読んだ時点で待機ロック解除
+5. **非常時のみ手動解除**: 通知異常時は `unlock_owner_wait` を使って解除できます
 
 ## マルチプロセス対応
 

--- a/src/config/role_permissions.py
+++ b/src/config/role_permissions.py
@@ -73,6 +73,7 @@ TOOL_PERMISSIONS: dict[str, list[str]] = {
     "send_message": ["owner", "admin", "worker"],
     "read_messages": ["owner", "admin", "worker"],
     "get_unread_count": ["owner", "admin", "worker"],
+    "unlock_owner_wait": ["owner"],
     # ========== ダッシュボード ==========
     "get_dashboard": ["owner", "admin", "worker"],
     "get_dashboard_summary": ["owner", "admin", "worker"],

--- a/src/context.py
+++ b/src/context.py
@@ -46,6 +46,8 @@ class AppContext:
     """セッションID（タスクディレクトリ名として使用）"""
     _admin_poll_state: dict[str, dict[str, Any]] = field(default_factory=dict)
     """Admin ごとのポーリングガード状態"""
+    _owner_wait_state: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """Owner ごとの待機ロック状態"""
     _admin_last_healthcheck_at: dict[str, datetime] = field(
         default_factory=dict
     )

--- a/src/tools/session_state.py
+++ b/src/tools/session_state.py
@@ -70,6 +70,7 @@ def _reset_app_context(app_ctx: AppContext) -> None:
     # セッションスコープのデータもクリア
     app_ctx.agents.clear()
     app_ctx._admin_poll_state.clear()
+    app_ctx._owner_wait_state.clear()
     app_ctx._admin_last_healthcheck_at.clear()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """pytest設定とフィクスチャ。"""
 
-import os
 import tempfile
 from datetime import datetime
 from pathlib import Path

--- a/tests/test_agent_helpers.py
+++ b/tests/test_agent_helpers.py
@@ -361,8 +361,14 @@ class TestSendTaskToWorker:
 
         with (
             patch("src.tools.agent_helpers.search_memory_context", return_value=[]),
-            patch("src.tools.agent_helpers.ensure_persona_manager", return_value=mock_persona_manager),
-            patch("src.tools.agent_helpers.get_mcp_tool_prefix_from_config", return_value="mcp__x__"),
+            patch(
+                "src.tools.agent_helpers.ensure_persona_manager",
+                return_value=mock_persona_manager,
+            ),
+            patch(
+                "src.tools.agent_helpers.get_mcp_tool_prefix_from_config",
+                return_value="mcp__x__",
+            ),
             patch("src.tools.agent_helpers.generate_7section_task", return_value="task body"),
             patch("src.tools.agent_helpers.ensure_dashboard_manager", return_value=mock_dashboard),
             patch("src.tools.agent_helpers.resolve_main_repo_root", return_value=str(temp_dir)),

--- a/tests/test_ai_cli_manager.py
+++ b/tests/test_ai_cli_manager.py
@@ -267,8 +267,14 @@ class TestResolveModelForCli:
 
     def test_explicit_model_mismatch_converted_to_cli_default(self):
         """CLI とモデルが不一致なら CLI デフォルトへ置換されることをテスト。"""
-        assert resolve_model_for_cli("codex", "gemini-3-pro", "admin") == ModelDefaults.CODEX_DEFAULT
-        assert resolve_model_for_cli("gemini", "gpt-5.3-codex", "worker") == ModelDefaults.GEMINI_LIGHT
+        assert (
+            resolve_model_for_cli("codex", "gemini-3-pro", "admin")
+            == ModelDefaults.CODEX_DEFAULT
+        )
+        assert (
+            resolve_model_for_cli("gemini", "gpt-5.3-codex", "worker")
+            == ModelDefaults.GEMINI_LIGHT
+        )
         assert resolve_model_for_cli("claude", "gemini-3-pro", "worker") == ModelDefaults.SONNET
 
     def test_none_model_returns_none(self):

--- a/tests/test_healthcheck_manager.py
+++ b/tests/test_healthcheck_manager.py
@@ -340,7 +340,7 @@ class TestHealthcheckMonitoring:
         )
         app_ctx.healthcheck_manager = healthcheck
 
-        pane_hash = hashlib.sha1("stable-pane-output".encode("utf-8")).hexdigest()
+        pane_hash = hashlib.sha1(b"stable-pane-output").hexdigest()
         healthcheck._pane_hash[worker.id] = pane_hash
         healthcheck._pane_last_changed_at[worker.id] = datetime.now() - timedelta(seconds=120)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -191,6 +191,97 @@ class TestCheckToolPermission:
         result = check_tool_permission(app_ctx, "list_agents", "test-owner")
         assert result is None
 
+    def test_owner_wait_lock_blocks_non_allowed_tool(self, app_ctx):
+        """Owner が待機ロック中は許可外ツールを拒否する。"""
+        now = datetime.now()
+        app_ctx.agents["owner-001"] = Agent(
+            id="owner-001",
+            role=AgentRole.OWNER,
+            status=AgentStatus.IDLE,
+            created_at=now,
+            last_activity=now,
+        )
+        app_ctx._owner_wait_state["owner-001"] = {
+            "waiting_for_admin": True,
+            "admin_id": "admin-001",
+            "session_id": "issue-001",
+            "locked_at": now,
+            "unlocked_at": None,
+            "unlock_reason": None,
+        }
+
+        result = check_tool_permission(app_ctx, "send_task", "owner-001")
+        assert result is not None
+        assert result["success"] is False
+        assert "owner_wait_locked" in result["error"]
+        assert result["waiting_for_admin_id"] == "admin-001"
+
+    def test_owner_wait_lock_allows_read_messages(self, app_ctx):
+        """Owner 待機ロック中でも read_messages は許可される。"""
+        now = datetime.now()
+        app_ctx.agents["owner-001"] = Agent(
+            id="owner-001",
+            role=AgentRole.OWNER,
+            status=AgentStatus.IDLE,
+            created_at=now,
+            last_activity=now,
+        )
+        app_ctx._owner_wait_state["owner-001"] = {
+            "waiting_for_admin": True,
+            "admin_id": "admin-001",
+            "session_id": "issue-001",
+            "locked_at": now,
+            "unlocked_at": None,
+            "unlock_reason": None,
+        }
+
+        result = check_tool_permission(app_ctx, "read_messages", "owner-001")
+        assert result is None
+
+    def test_owner_wait_lock_allows_get_unread_count(self, app_ctx):
+        """Owner 待機ロック中でも get_unread_count は許可される。"""
+        now = datetime.now()
+        app_ctx.agents["owner-001"] = Agent(
+            id="owner-001",
+            role=AgentRole.OWNER,
+            status=AgentStatus.IDLE,
+            created_at=now,
+            last_activity=now,
+        )
+        app_ctx._owner_wait_state["owner-001"] = {
+            "waiting_for_admin": True,
+            "admin_id": "admin-001",
+            "session_id": "issue-001",
+            "locked_at": now,
+            "unlocked_at": None,
+            "unlock_reason": None,
+        }
+
+        result = check_tool_permission(app_ctx, "get_unread_count", "owner-001")
+        assert result is None
+
+    def test_owner_wait_lock_allows_unlock_tool(self, app_ctx):
+        """Owner 待機ロック中でも unlock_owner_wait は許可される。"""
+        now = datetime.now()
+        app_ctx.agents["owner-001"] = Agent(
+            id="owner-001",
+            role=AgentRole.OWNER,
+            status=AgentStatus.IDLE,
+            created_at=now,
+            last_activity=now,
+        )
+        app_ctx._owner_wait_state["owner-001"] = {
+            "waiting_for_admin": True,
+            "admin_id": "admin-001",
+            "session_id": "issue-001",
+            "locked_at": now,
+            "unlocked_at": None,
+            "unlock_reason": None,
+        }
+
+        result = check_tool_permission(app_ctx, "unlock_owner_wait", "owner-001")
+        assert result is None
+
     def test_disallowed_role_returns_error(self, app_ctx):
         """許可ロールに含まれないエージェントはエラーを返す。"""
         now = datetime.now()

--- a/tests/test_helpers_persistence.py
+++ b/tests/test_helpers_persistence.py
@@ -1,10 +1,7 @@
 """helpers_persistence.py のユニットテスト。"""
 
 import json
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from src.tools.helpers_persistence import delete_agents_file
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,10 +1,7 @@
 """merge.py のユニットテスト。"""
 
 import subprocess
-from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from src.tools.merge import _is_branch_merged, _run_git
 

--- a/tests/test_server_lifecycle.py
+++ b/tests/test_server_lifecycle.py
@@ -1,10 +1,6 @@
 """server.py ライフサイクルのテスト（異常終了シナリオ）。"""
 
 import json
-from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
 
 from src.server import _save_shutdown_state
 

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -2,12 +2,8 @@
 
 import json
 from enum import Enum
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
-from src.config.settings import Settings
 from src.tools.session_env import (
     _format_env_value,
     _setup_mcp_directories,

--- a/tests/tools/test_worktree_tools.py
+++ b/tests/tools/test_worktree_tools.py
@@ -1,7 +1,7 @@
 """Git worktree管理ツールのテスト。"""
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary
- enforce Owner wait-lock after successful `send_task` (Owner -> Admin)
- block non-allowed Owner tools while waiting (`read_messages`, `get_unread_count`, `unlock_owner_wait` only)
- add Owner polling guard in `read_messages` and auto-unlock on Admin message consumption
- add `unlock_owner_wait` MCP tool (owner-only) for emergency manual unlock
- clear Owner wait state during session reset
- sync docs (`templates/roles/owner.md`, `docs/ipc.md`)
- fix existing `ruff check` issues in tests so lint passes

## Validation
- `uv run ruff check src tests`
- `uv run pytest`

## Notes
- includes test coverage for permission lock behavior, send_task lock transition, read_messages unlock behavior, and idempotent manual unlock
